### PR TITLE
Replace unsafe shooting star functions with iterator

### DIFF
--- a/js/model.ts
+++ b/js/model.ts
@@ -1,7 +1,7 @@
 export enum DayType { NoData = 0, None, Shower, Rainbow, Aurora }
 export enum ShowerType { NotSure = 0, Light, Heavy }
 
-import {Hemisphere, Weather, SpecialDay, getMonthLength, Pattern, getPattern, getWeather, getWindPower, isSpecialDay, SnowLevel, CloudLevel, FogLevel, getSnowLevel, getCloudLevel, getFogLevel, checkWaterFog, getRainbowInfo, isAuroraPattern, fromLinearHour, toLinearHour, canHaveShootingStars, queryStars, getStarSecond, isLightShowerPattern, isHeavyShowerPattern, isPatternPossibleAtDate, GuessData, getPatternKind, PatternKind, SpWeatherLevel, getSpWeatherLevel, Constellation, getConstellation, getWindPowerMin, getWindPowerMax, getSpecialCloudInfo, SpecialCloud} from '../pkg'
+import {Hemisphere, Weather, SpecialDay, getMonthLength, Pattern, getPattern, getWeather, getWindPower, isSpecialDay, SnowLevel, CloudLevel, FogLevel, getSnowLevel, getCloudLevel, getFogLevel, checkWaterFog, getRainbowInfo, isAuroraPattern, fromLinearHour, toLinearHour, canHaveShootingStars, queryStars, getStarSecond, isLightShowerPattern, isHeavyShowerPattern, isPatternPossibleAtDate, GuessData, getPatternKind, PatternKind, SpWeatherLevel, getSpWeatherLevel, Constellation, getConstellation, getWindPowerMin, getWindPowerMax, getSpecialCloudInfo, SpecialCloud, StarsIterator} from '../pkg'
 export {Hemisphere, Weather, SpecialDay, getMonthLength}
 
 export enum AmbiguousWeather {
@@ -628,12 +628,15 @@ export class DayForecast {
 				const hour = fromLinearHour(linearHour)
 				if (canHaveShootingStars(hour, this.pattern)) {
 					for (let minute = 0; minute < 60; minute++) {
-						const starCount = queryStars(seed, year, month, day, hour, minute, this.pattern)
-						if (starCount > 0) {
-							const star: StarInfo = {hour, minute, seconds: []}
-							for (let i = 0; i < starCount; i++) {
-								star.seconds.push(getStarSecond(i))
-							}
+						const starsIterator = new StarsIterator(seed, year, month, day, hour, minute, this.pattern);
+						const star: StarInfo = {hour, minute, seconds: []}
+						let second = undefined;
+
+						while ((second = starsIterator.next()) != undefined) {
+							star.seconds.push(second);
+						}
+
+						if (star.seconds.length > 0) {
 							this.shootingStars.push(star)
 						}
 					}

--- a/js/model.ts
+++ b/js/model.ts
@@ -630,9 +630,10 @@ export class DayForecast {
 					for (let minute = 0; minute < 60; minute++) {
 						const starsIterator = new StarsIterator(seed, year, month, day, hour, minute, this.pattern);
 						const star: StarInfo = {hour, minute, seconds: []}
-						let second = undefined;
 
-						while ((second = starsIterator.next()) != undefined) {
+						while (starsIterator.hasNext()) {
+							const second = starsIterator.next()!;
+
 							star.seconds.push(second);
 						}
 

--- a/js/model.ts
+++ b/js/model.ts
@@ -1,7 +1,7 @@
 export enum DayType { NoData = 0, None, Shower, Rainbow, Aurora }
 export enum ShowerType { NotSure = 0, Light, Heavy }
 
-import {Hemisphere, Weather, SpecialDay, getMonthLength, Pattern, getPattern, getWeather, getWindPower, isSpecialDay, SnowLevel, CloudLevel, FogLevel, getSnowLevel, getCloudLevel, getFogLevel, checkWaterFog, getRainbowInfo, isAuroraPattern, fromLinearHour, toLinearHour, canHaveShootingStars, queryStars, getStarSecond, isLightShowerPattern, isHeavyShowerPattern, isPatternPossibleAtDate, GuessData, getPatternKind, PatternKind, SpWeatherLevel, getSpWeatherLevel, Constellation, getConstellation, getWindPowerMin, getWindPowerMax, getSpecialCloudInfo, SpecialCloud, StarsIterator} from '../pkg'
+import {Hemisphere, Weather, SpecialDay, getMonthLength, Pattern, getPattern, getWeather, getWindPower, isSpecialDay, SnowLevel, CloudLevel, FogLevel, getSnowLevel, getCloudLevel, getFogLevel, checkWaterFog, getRainbowInfo, isAuroraPattern, fromLinearHour, toLinearHour, canHaveShootingStars, isLightShowerPattern, isHeavyShowerPattern, isPatternPossibleAtDate, GuessData, getPatternKind, PatternKind, SpWeatherLevel, getSpWeatherLevel, Constellation, getConstellation, getWindPowerMin, getWindPowerMax, getSpecialCloudInfo, SpecialCloud, StarsIterator} from '../pkg'
 export {Hemisphere, Weather, SpecialDay, getMonthLength}
 
 export enum AmbiguousWeather {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -665,9 +665,14 @@ impl StarsIterator {
 		}
 	}
 
+	#[wasm_bindgen(js_name = hasNext)]
+	pub fn has_next(&self) -> bool {
+		self.star_count > 0
+	}
+
 	#[allow(clippy::should_implement_trait)]
 	pub fn next(&mut self) -> Option<u8> {
-		if self.star_count == 0 {
+		if !self.has_next() {
 			return None;
 		}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -641,9 +641,6 @@ fn query_stars_internal(seed_base: u32, minute: u8, pattern: Pattern) -> Option<
 }
 
 
-
-static mut LAST_STAR_SECONDS: [u8;8] = [0;8];
-
 #[wasm_bindgen]
 pub struct StarsIterator {
 	star_count: u8,
@@ -688,32 +685,6 @@ impl StarsIterator {
 		None
 	}
 }
-
-#[wasm_bindgen(js_name = queryStars)]
-pub fn query_stars(seed: u32, year: u16, month: u8, day: u8, hour: u8, minute: u8, pattern: Pattern) -> u8 {
-	let (year, month, day) = normalise_late_ymd(year, month, day, hour);
-	let seed = compute_seed_ymdh(seed, 0x20000, 0x2000, 0x100, 0x10000, year, month, day, hour);
-	match query_stars_internal(seed, minute, pattern) {
-		None => 0,
-		Some((star_count, star_field)) => {
-			let mut index = 0;
-			for second in 0..60 {
-				let mask = 1u64 << second;
-				if (star_field & mask) != 0 {
-					unsafe { LAST_STAR_SECONDS[index] = second; }
-					index += 1;
-				}
-			}
-			star_count
-		}
-	}
-}
-#[wasm_bindgen(js_name = getStarSecond)]
-pub fn get_star_second(index: usize) -> u8 {
-	unsafe { LAST_STAR_SECONDS[index] }
-}
-
-
 
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
The current shooting star functions (`query_stars`, `get_star_second`) unsafely use a global mutable static array (`LAST_STAR_SECONDS`). This is not a real issue for usage on the website, but it is an issue for the project that I'm currently working on.

This PR replaces those functions with a safe iterator :smiley:.